### PR TITLE
Fix missing Content-Disposition header in the file export response

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,3 +37,6 @@ class Config:
     # THRESHOLD ALARMS
     EMAIL_MQTT_CHANNEL = environ.get("EMAIL_MQTT_CHANNEL")
     THRESHOLD_UNIT = environ.get("THRESHOLD_UNIT")
+    
+    # CORS
+    CORS_EXPOSE_HEADERS=['Content-Disposition']


### PR DESCRIPTION
The header contains required data, such as the filename of exported file.